### PR TITLE
Update/across session creds

### DIFF
--- a/APIInstanceClass.js
+++ b/APIInstanceClass.js
@@ -1,4 +1,4 @@
 // A simple reference to the API instance class for type checking
-const APIInstanceClass = require('caccl-api/classes/EndpointCategory'); // TODO: use real module
+const APIInstanceClass = require('caccl-api/classes/EndpointCategory');
 
 module.exports = APIInstanceClass;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.1.0
+
+Major breaking authorization change: instead of accessTokens being stored in the user's session, they are stored in the tokenStore. This means two things: first, that CACCL now supports users being logged into your app in more than one session, and second, that tokenStores must be able to store slightly larger payloads (instead of just the refreshToken, we are now also storing accessToken and expiry timestamp).
+
 ## 1.0.106
 
 CACCL Canvas Partial Simulator: Fixed bug where nav launches didn't send proper credentials.

--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ _Get Info on Status, Auth, and LTI Launch:_
 _Grade Passback:_
 
 > CACCL supports LTI-based grade passback when the user was launched through an external assignment. If the user launched this way, you will be able to use the `sendPassback` function on the server to pass grade, timestamp, and/or submission data back to Canvas:
-> 
+>
 > In any server route, use the `req.sendPassback` function with the following parameters:
-> 
+>
 > Property | Type | Description
 > :--- | :--- | :---
 > score | number | the number of points to give the student. Either this or `percent` can be included, but not both
@@ -121,18 +121,18 @@ _Grade Passback:_
 > text | string | the student's text submission. Either this or `url` can be included, but not both
 > url | string | the student's url submission. Either this or `text` can be included, but not both
 > submittedAt | Date or ISO 8601 string | the submittedAt timestamp for the submission
-> 
+>
 > Example 1: on this 20 point assignment, give the student 15 points and send their text submission
-> 
+>
 > ```js
 > await req.sendPassback({
 >   score: 15,
 >   text: 'This is my submission',
 > });
 > ```
-> 
+>
 > Example 2: on this 20 point assignment, give the student 15 points and send their url submission
-> 
+>
 > ```js
 > await req.sendPassback({
 >   percent: 75,
@@ -242,9 +242,9 @@ _Sending requests to the server:_
 _Grade Passback:_
 
 > CACCL supports LTI-based grade passback on the front-end when the user was launched through an external assignment and when the server has `disableClientSidePassback` set to `false` (this is the default). Use the `sendPassback` function provided by `initCACCL` to pass grade, timestamp, and/or submission data back to Canvas:
-> 
+>
 > In any React component, use `sendPassback` with the following parameters:
-> 
+>
 > Property | Type | Description
 > :--- | :--- | :---
 > score | number | the number of points to give the student. Either this or `percent` can be included, but not both
@@ -252,18 +252,18 @@ _Grade Passback:_
 > text | string | the student's text submission. Either this or `url` can be included, but not both
 > url | string | the student's url submission. Either this or `text` can be included, but not both
 > submittedAt | Date or ISO 8601 string | the submittedAt timestamp for the submission
-> 
+>
 > Example 1: on this 20 point assignment, give the student 15 points and send their text submission
-> 
+>
 > ```js
 > await sendPassback({
 >   score: 15,
 >   text: 'This is my submission',
 > });
 > ```
-> 
+>
 > Example 2: on this 20 point assignment, give the student 15 points and send their url submission
-> 
+>
 > ```js
 > await sendPassback({
 >   percent: 75,
@@ -339,7 +339,7 @@ _Configuration for Canvas authorization:_
 > disableAuthorization | boolean | if false, sets up automatic authorization when the user visits the launchPath | `false`
 > developerCredentials | object | Canvas app developer credentials in the form `{ client_id, client_secret }`. No need to include this in your dev environment (the default value is what we expect) | `{ client_id: 'client_id', client_secret: 'client_secret' }` (our dummy vals for dev environment)
 > defaultAuthorizedRedirect | string | the default route to redirect the user to after authorization is complete (you can override this for a specific authorization call by including `next=/path` as a query or body parameter when sending user to the launchPath) | "/"
-> tokenStore | [TokenStore](https://github.com/harvard-edtech/caccl-authorizer/blob/master/docs/TokenStore.md) | null to turn off storage of refresh tokens or custom token store of form `{ get(key), set(key, val) }` where both get and set functions return promises | memory token store
+> tokenStore | [TokenStore](https://github.com/harvard-edtech/caccl-authorizer/blob/master/docs/TokenStore.md) | include a custom token store (see [TokenStore docs](https://github.com/harvard-edtech/caccl-authorizer/blob/master/docs/TokenStore.md) for specs) | memory token store
 > simulateLaunchOnAuthorize | boolean | if true, simulates an LTI launch upon successful authorization (if user hasn't already launched via LTI), essentially allowing users to launc the tool by visiting the launchPath (GET). _Note:_ `simulateLaunchOnAuthorize` is not valid unless `disableAuthorization`, `disableLTI`, and `disableServerSideAPI` are all false. | `false`
 
 _Configuration for LTI launches:_
@@ -716,9 +716,9 @@ _Get Info on Status, Auth, and LTI Launch:_
 _Grade Passback:_
 
 > CACCL supports LTI-based grade passback when the user was launched through an external assignment. If the user launched this way, you will be able to use the `sendPassback` function on the server to pass grade, timestamp, and/or submission data back to Canvas:
-> 
+>
 > In any server route, use the `req.sendPassback` function with the following parameters:
-> 
+>
 > Property | Type | Description
 > :--- | :--- | :---
 > score | number | the number of points to give the student. Either this or `percent` can be included, but not both
@@ -726,18 +726,18 @@ _Grade Passback:_
 > text | string | the student's text submission. Either this or `url` can be included, but not both
 > url | string | the student's url submission. Either this or `text` can be included, but not both
 > submittedAt | Date or ISO 8601 string | the submittedAt timestamp for the submission
-> 
+>
 > Example 1: on this 20 point assignment, give the student 15 points and send their text submission
-> 
+>
 > ```js
 > await req.sendPassback({
 >   score: 15,
 >   text: 'This is my submission',
 > });
 > ```
-> 
+>
 > Example 2: on this 20 point assignment, give the student 15 points and send their url submission
-> 
+>
 > ```js
 > await req.sendPassback({
 >   percent: 75,
@@ -838,7 +838,7 @@ _Configuration for Canvas authorization:_
 > disableAuthorization | boolean | if false, sets up automatic authorization when the user visits the launchPath | `false`
 > developerCredentials | object | Canvas app developer credentials in the form `{ client_id, client_secret }`. No need to include this in your dev environment (the default value is what we expect) | `{ client_id: 'client_id', client_secret: 'client_secret' }` (our dummy vals for dev environment)
 > defaultAuthorizedRedirect | string | the default route to redirect the user to after authorization is complete (you can override this for a specific authorization call by including `next=/path` as a query or body parameter when sending user to the launchPath) | "/"
-> tokenStore | [TokenStore](https://github.com/harvard-edtech/caccl-authorizer/blob/master/docs/TokenStore.md) | null to turn off storage of refresh tokens or custom token store of form `{ get(key), set(key, val) }` where both get and set functions return promises | memory token store
+> tokenStore | [TokenStore](https://github.com/harvard-edtech/caccl-authorizer/blob/master/docs/TokenStore.md) | include a custom token store (see [TokenStore docs](https://github.com/harvard-edtech/caccl-authorizer/blob/master/docs/TokenStore.md) for specs) | memory token store
 > simulateLaunchOnAuthorize | boolean | if true, simulates an LTI launch upon successful authorization (if user hasn't already launched via LTI), essentially allowing users to launc the tool by visiting the launchPath (GET). _Note:_ `simulateLaunchOnAuthorize` is not valid unless `disableAuthorization`, `disableLTI`, and `disableServerSideAPI` are all false. | `false`
 
 _Configuration for LTI launches:_

--- a/canvas/startPartialSimulation.js
+++ b/canvas/startPartialSimulation.js
@@ -1,1 +1,2 @@
+// Import partial simulator and it will immediately start up
 require('caccl-canvas-partial-simulator');

--- a/client/cached.js
+++ b/client/cached.js
@@ -1,3 +1,7 @@
+// Import stringify library
+const stringify = require('fast-json-stable-stringify');
+
+// Import local modules
 const initCACCL = require('.');
 
 const cacclInstanceCache = {}; // jsonified config => CACCL instance
@@ -11,7 +15,7 @@ const cacclInstanceCache = {}; // jsonified config => CACCL instance
  * @return {object} same response as /client/index.js
  */
 module.exports = (config = {}) => {
-  const cacheKey = JSON.stringify(config);
+  const cacheKey = stringify(config);
 
   // Create new instance if not already available
   if (!cacclInstanceCache[cacheKey]) {

--- a/client/cached.js
+++ b/client/cached.js
@@ -2,6 +2,14 @@ const initCACCL = require('.');
 
 const cacclInstanceCache = {}; // jsonified config => CACCL instance
 
+/**
+ * Memoized version of the initialization function. If given the same config
+ *   options, this function will return the previously initialized caccl
+ *   instance
+ * @author Gabe Abrams
+ * @param {object} config - the same arguments as allowed in /client/index.js
+ * @return {object} same response as /client/index.js
+ */
 module.exports = (config = {}) => {
   const cacheKey = JSON.stringify(config);
 

--- a/genExpressApp.js
+++ b/genExpressApp.js
@@ -14,7 +14,7 @@ const initPrint = require('./validateConfigAndSetDefaults/helpers/initPrint');
 /**
  * Creates a new express app with memory-based session, listening on env PORT or
  *   8080, and with randomized session secret and cookie name.
- * @author Gabriel Abrams
+ * @author Gabe Abrams
  * @param {number} [port=process.env.PORT || 443] - the port to listen
  *   to
  * @param {boolean} [forceSSL=port is 443 or sslKey and sslCertificate included]
@@ -54,7 +54,6 @@ module.exports = (config = {}) => {
     }
     port = parseInt(port);
   }
-
 
   if (config.verbose) {
     print.subtitle('Creating a new express app:');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "caccl",
-  "version": "1.0.133",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1454,9 +1454,9 @@
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "caccl",
-  "version": "1.0.133",
+  "version": "1.1.0",
   "description": "Canvas App Complete Connection Library: an all-in-one library for connecting your app to Canvas, handling lti, access tokens, and api.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "caccl-send-request": "^1.0.13",
     "express": "^4.17.1",
     "express-session": "^1.17.0",
+    "fast-json-stable-stringify": "^2.1.0",
     "fs": "0.0.1-security",
     "http": "0.0.0",
     "https": "^1.0.0",

--- a/script.js
+++ b/script.js
@@ -4,6 +4,7 @@ const validateConfigAndSetDefaults = require('./validateConfigAndSetDefaults/scr
 
 /**
  * Initialize a caccl-enabled script
+ * @author Gabe Abrams
  * @param {string} [config.accessToken] - An access token to add to all
  *   requests. Can be overridden by including `access_token` query/body
  *   parameter.

--- a/server/helpers/initPassback.js
+++ b/server/helpers/initPassback.js
@@ -5,6 +5,7 @@ const errorCodes = require('../../errorCodes');
 
 /**
  * Initializes LTI 1.1 Grade Passback
+ * @author Gabe Abrams
  * @param {object} opts - an object containing all arguments
  * @param {Express App} opts.app - the express app to add routes to
  * @param {string} opts.apiForwardPathPrefix - the prefix to add before all
@@ -29,6 +30,22 @@ module.exports = (opts) => {
 
   // Add middleware to add grade passback functionality
   app.use('*', (req, res, next) => {
+    /**
+     * Send a passback request
+     * @author Gabe Abrams
+     * @param {object} request - an object containing all the information for
+     *   the passback request
+     * @param {string} [request.text] - the text of the submission. If this is
+     *   included, url cannot be included
+     * @param {string} [request.url] - a url to send as the student's
+     *   submission. If this is included, text cannot be included
+     * @param {number} [request.score] - the student's score on this assignment
+     * @param {number} [request.percent] - the student's score as a percent
+     *   (0-100) on the assignment
+     * @param {Date|string} [request.submittedAt=now] - a timestamp for when the
+     *   student submitted the grade. The type must either be a Date object or
+     *   an ISO 8601 formatted string
+     */
     req.sendPassback = async (request) => {
       // Make sure the request contains something to submit
       if (

--- a/server/react.js
+++ b/server/react.js
@@ -10,7 +10,7 @@ const initCACCL = require('.');
 
 /**
  * Initializes the CACCL library
- * @author Gabriel Abrams
+ * @author Gabe Abrams
  * APP:
  * @param {object} [app=generate new express app] - the express app to use and
  *   add middleware to. If excluded, we generate a new express app (see
@@ -80,8 +80,7 @@ const initCACCL = require('.');
  *   body.next, a path/url to visit after completion)
  * @param {object|null} [tokenStore=memory token store] - null to turn off
  *   storage of refresh tokens, exclude to use memory token store,
- *   or include a custom token store of form { get(key), set(key, val) } where
- *   both functions return promises
+ *   or include a custom token store (see docs in caccl-authorizer project)
  * @param {boolean} [simulateLaunchOnAuthorize] - if truthy, simulates an LTI
  *   launch upon successful authorization (if the user hasn't already launched
  *   via LTI), essentially allowing users to either launch via LTI or launch

--- a/validateConfigAndSetDefaults/client.js
+++ b/validateConfigAndSetDefaults/client.js
@@ -1,5 +1,11 @@
 const initPrint = require('./helpers/initPrint');
 
+/**
+ * Validates client configuration options and makes changes (sets defaults etc.)
+ * @author Gabe Abrams
+ * @param {object} oldConfig - the current configuration object
+ * @return {object} the new configuration object
+ */
 module.exports = (oldConfig) => {
   const config = oldConfig;
   const print = initPrint(config.verbose);

--- a/validateConfigAndSetDefaults/helpers/initPrint.js
+++ b/validateConfigAndSetDefaults/helpers/initPrint.js
@@ -6,47 +6,57 @@ const print = {};
 
 /**
  * Prints a new console header
+ * @author Gabe Abrams
  * @param {string} str - the string to print
  */
 print.head = (str) => {
+  // eslint-disable-next-line no-console
   console.log(`\n${str}`);
 };
 
 /**
  * Prints the status for a configuration variable
+ * @author Gabe Abrams
  * @param {string} name - the name of the variable
  * @param {boolean} isIncluded - if truthy, variable is marked as "included",
  *   otherwise marked as "excluded"
  * @param {string} [explanation] - added as a second line
  */
 print.variable = (name, isIncluded, explanation) => {
+  // eslint-disable-next-line no-console
   console.log(`- ${isIncluded ? print.inGreen('included') : print.inYellow('excluded')}: "${name}"${explanation ? '\n' : ''}${print.inGray(explanation)}`);
 };
 
 /**
  * Prints the status for a configuration boolean
+ * @author Gabe Abrams
  * @param {string} name - the name of the boolean
  * @param {boolean} value - if truthy, variable is marked as "true",
  *   otherwise marked as "false"
  * @param {string} [explanation] - added as a second line
  */
 print.boolean = (name, value, explanation) => {
+  // eslint-disable-next-line no-console
   console.log(`- ${value ? print.inGreen('true') : print.inYellow('false')}: "${name}"${explanation ? '\n' : ''}${print.inGray(explanation)}`);
 };
 
 /**
  * Prints a subtitle (grayed out item, indented once)
+ * @author Gabe Abrams
  * @param {string} str - the text in the subtitle
  */
 print.subtitle = (str) => {
+  // eslint-disable-next-line no-console
   console.log(print.inGray(`   - ${str}`));
 };
 
 /**
  * Prints a subsubtitle (grayed out item, indented twice)
+ * @author Gabe Abrams
  * @param {string} str - the text in the subtitle
  */
 print.subsubtitle = (str) => {
+  // eslint-disable-next-line no-console
   console.log(print.inGray(`     - ${str}`));
 };
 
@@ -97,7 +107,13 @@ Object.keys(print).forEach((key) => {
   printNonVerbose[key] = () => { return ''; };
 });
 
-
+/**
+ * Return a print object or a dummy object if verbose is false
+ * @author Gabe Abrams
+ * @param {boolean} [verbose] - if true, print function that's returned will
+ *   actually print (otherwise, it will do nothing)
+ * @return {function} print function
+ */
 module.exports = (verbose) => {
   if (verbose) {
     return print;

--- a/validateConfigAndSetDefaults/script.js
+++ b/validateConfigAndSetDefaults/script.js
@@ -1,5 +1,11 @@
 const initPrint = require('./helpers/initPrint');
 
+/**
+ * Validates script configuration options and makes changes (sets defaults etc.)
+ * @author Gabe Abrams
+ * @param {object} oldConfig - the current configuration object
+ * @return {object} the new configuration object
+ */
 module.exports = (oldConfig) => {
   const config = oldConfig;
   const print = initPrint(config.verbose);

--- a/validateConfigAndSetDefaults/server.js
+++ b/validateConfigAndSetDefaults/server.js
@@ -449,18 +449,18 @@ module.exports = (oldConfig) => {
       // We don't have authorization. The programmer will need to manually add
       // access tokens
       if (config.accessToken) {
-        print.boolean('disableAuthorization', true, 'warning: the api is enabled but authorization is disabled, so the default access token you included ("accessToken") will be used unless you manually authorize users. You can manually authorize a user by adding users\' access tokens to their session: req.session.accessToken');
+        print.boolean('disableAuthorization', true, 'warning: the api is enabled but authorization is disabled, so the default access token you included ("accessToken") will be used unless you manually authorize users. You can manually authorize a user by adding users\' access tokens to their session: req.accessToken');
       } else {
-        print.boolean('disableAuthorization', true, 'warning: the api is enabled but authorization is disabled, so you will need to manually authorize users. You can do this by adding users\' access tokens to req.session.accessToken');
+        print.boolean('disableAuthorization', true, 'warning: the api is enabled but authorization is disabled, so you will need to manually authorize users. You can do this by adding users\' access tokens to req.accessToken');
       }
     } else {
       print.boolean('disableAuthorization', false, 'this is the recommended value: the api is enabled and authorization is enabled so users can be authorized for api access');
     }
   // The API is disabled. We have no need for authorization
   } else if (config.disableAuthorization) {
-    print.boolean('disableAuthorization', true, 'this is the recommended value: the api is disabled so we don\'t need authorization enabled unless you plan on manually using users\' access tokens in your own code while not using our CACCL api functionality (access tokens are added as req.session.accessToken)');
+    print.boolean('disableAuthorization', true, 'this is the recommended value: the api is disabled so we don\'t need authorization enabled unless you plan on manually using users\' access tokens in your own code while not using our CACCL api functionality (access tokens are added as req.accessToken)');
   } else {
-    print.boolean('disableAuthorization', false, 'though the api is disabled, authorization is still enabled. This is only useful if you plan on manually using users\' access tokens in your own code while not using our CACCL api functionality (access tokens are added as req.session.accessToken)');
+    print.boolean('disableAuthorization', false, 'though the api is disabled, authorization is still enabled. This is only useful if you plan on manually using users\' access tokens in your own code while not using our CACCL api functionality (access tokens are added as req.accessToken)');
   }
 
   // defaultAuthorizedRedirect

--- a/validateConfigAndSetDefaults/server.js
+++ b/validateConfigAndSetDefaults/server.js
@@ -3,6 +3,12 @@ const path = require('path');
 const initPrint = require('./helpers/initPrint');
 const genExpressApp = require('../genExpressApp');
 
+/**
+ * Validates server configuration options and makes changes (sets defaults etc.)
+ * @author Gabe Abrams
+ * @param {object} oldConfig - the current configuration object
+ * @return {object} the new configuration object
+ */
 module.exports = (oldConfig) => {
   const config = oldConfig;
   const print = initPrint(config.verbose);


### PR DESCRIPTION
This is part of a large across-caccl change to switch access tokens from being in the session to being in the tokenStore. This will solve token race conditions between sessions of the same user and will make it possible for users to be logged into the same app on different machines without causing issues with Canvas, though this does make it possible for users to get closer to throttling limits.